### PR TITLE
Round percentages in comparison output to 1 decimal

### DIFF
--- a/lib/likadan_runner.rb
+++ b/lib/likadan_runner.rb
@@ -58,7 +58,7 @@ begin
         if img = comparison[:diff_image]
           diff_output = LikadanUtils.path_to(current['name'], width, 'diff.png')
           img.save(diff_output)
-          puts "#{comparison[:diff_in_percent]}% (#{diff_output})"
+          puts "#{comparison[:diff_in_percent].round(1)}% (#{diff_output})"
         else
           File.delete(output_file)
           puts 'No diff.'


### PR DESCRIPTION
These floats were pretty long, with way more significant figures than is
actually useful. Rounding it to 1 decimal place cleans up the output a
little.