### PR TITLE
Disable pointer events on likadan runner HTML

### DIFF
--- a/lib/views/index.erb
+++ b/lib/views/index.erb
@@ -17,7 +17,7 @@
         href="/resource?file=<%= ERB::Util.url_encode(stylesheet) %>">
     <% end %>
   </head>
-  <body style="margin: 0; background-color: #fff;">
+  <body style="background-color: #fff; margin: 0; pointer-events: none;">
     <script src="/likadan-runner.js"></script>
     <% @config['source_files'].each do |source_file| %>
       <script src="/resource?file=<%= ERB::Util.url_encode(source_file) %>"></script>


### PR DESCRIPTION
When running likadan locally, I sometimes leave my mouse cursor over the
Firefox window. This sometimes causes a hover style to be activated,
which causes an unnecessary diff. To prevent this from happening, this
commit disables pointer events on everything that is rendered.