### PR TITLE
Rename `likadan prune` to `likadan clean`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Uploads all current diff images to an Amazon S3 account and reports back URLs
 to access those diff images. Requires the `s3_access_key_id` and
 `s3_secret_access_key` configuration options.
 
-### `likadan prune`
+### `likadan clean`
 
 Recursively removes everything in the snapshots folder (configured through
-`snapshot_folder`).
+`snapshots_folder`).

--- a/bin/likadan
+++ b/bin/likadan
@@ -21,7 +21,7 @@ when 'review'
   system 'open', LikadanUtils.construct_url('/review')
   require 'likadan_server'
 
-when 'prune'
+when 'clean'
   FileUtils.remove_entry_secure LikadanUtils.config['snapshots_folder']
 
 when 'approve', 'reject'


### PR DESCRIPTION
@lencioni pointed out [1] that this name was confusing, and better suited
for a feature that would remove any obsolete (old examples no longer
existing) examples.

"clean" is a better name, and is more similar to e.g. `make clean` `ant
clean` etc.

[1]: https://github.com/trotzig/likadan/issues/8