### PR TITLE
Fix `likadan clean` for missing snapshots folder

### DIFF
--- a/bin/likadan
+++ b/bin/likadan
@@ -22,7 +22,9 @@ when 'review'
   require 'likadan_server'
 
 when 'clean'
-  FileUtils.remove_entry_secure LikadanUtils.config['snapshots_folder']
+  if File.directory? LikadanUtils.config['snapshots_folder']
+    FileUtils.remove_entry_secure LikadanUtils.config['snapshots_folder']
+  end
 
 when 'approve', 'reject'
   abort 'Missing example name' unless example_name = ARGV[1]


### PR DESCRIPTION
Running `likadan clean` when the snapshots folder was missing would lead
to an error (something like "No such file or directory"). Since it's
likely that `likadan clean` will be added to scripts, I want it to be
more robust. Adding a guard to make sure that the folder exists will
help.