### PR TITLE
Surface JavaScript errors that happen during initialization

### DIFF
--- a/lib/likadan_runner.rb
+++ b/lib/likadan_runner.rb
@@ -21,6 +21,12 @@ driver = Selenium::WebDriver.for LikadanUtils.config['driver'].to_sym
 begin
   driver.navigate.to LikadanUtils.construct_url('/')
 
+  # Check for errors during startup
+  errors = driver.execute_script('return window.likadan.errors;')
+  unless errors.empty?
+    fail "JavaScript errors found during initialization: \n#{errors.inspect}"
+  end
+
   while current = driver.execute_script('return window.likadan.next()') do
     resolve_viewports(current).each do |viewport|
       # Resize window to the right size before rendering

--- a/lib/public/likadan-runner.js
+++ b/lib/public/likadan-runner.js
@@ -3,6 +3,7 @@ window.likadan = {
   currentIndex: 0,
   currentExample: undefined,
   currentRenderedElement: undefined,
+  errors: [],
 
   define: function(name, func, options) {
     this.defined.push({
@@ -118,3 +119,7 @@ window.prompt = function(message, value) {
   console.log('`window.prompt` called', message, value);
   return null;
 };
+
+window.onerror = function(message, url, lineNumber) {
+  window.likadan.errors.push({ message: message, url: url, lineNumber: lineNumber });
+}


### PR DESCRIPTION
We've had issues with js errors making likadan silently fail (a firefox
window opens, then closes - no examples have been run). Adding some code
to record all errors happening and then throwing an error from ruby code
will at least make those errors more visible.

Fixes #18