### PR TITLE
Set <body> min-height to 1px on runner document

### DIFF
--- a/lib/views/index.erb
+++ b/lib/views/index.erb
@@ -17,7 +17,7 @@
         href="/resource?file=<%= ERB::Util.url_encode(stylesheet) %>">
     <% end %>
   </head>
-  <body style="background-color: #fff; margin: 0; pointer-events: none;">
+  <body style="background-color: #fff; margin: 0; min-height: 1px; pointer-events: none;">
     <script src="/likadan-runner.js"></script>
     <% @config['source_files'].each do |source_file| %>
       <script src="/resource?file=<%= ERB::Util.url_encode(source_file) %>"></script>


### PR DESCRIPTION
I was using likadan recently and came across an interesting error:

> Invalid image size, width: 320, height: 0

I have an example that renders a component that happens to take up 0
height. Likadan is just fine with this on the first pass, but on the
second pass when comparing a new version against a baseline, it
blows up with this error.

To prevent this from happening, I am setting a min-height of 1px on the
<body> element. If I understand how this works correctly, this will
cause the snapshot to be at least 1px tall, so it should never store a
0px tall image and run into this problem.

We may want to implement a more thorough fix for this issue at some
point, but this is simple and should at least help people out now.

Fixes #23