### PR TITLE
Avoid creating multiple S3 buckets

### DIFF
--- a/lib/likadan_runner.rb
+++ b/lib/likadan_runner.rb
@@ -17,7 +17,16 @@ def resolve_viewports(example)
   end
 end
 
-driver = Selenium::WebDriver.for LikadanUtils.config['driver'].to_sym
+begin
+  driver = Selenium::WebDriver.for LikadanUtils.config['driver'].to_sym
+rescue Selenium::WebDriver::Error::WebDriverError
+  # "unable to obtain stable firefox connection in 60 seconds"
+  #
+  # This seems to happen sporadically for some versions of Firefox, so we want
+  # to retry it in case it will work the second time around.
+  driver = Selenium::WebDriver.for LikadanUtils.config['driver'].to_sym
+end
+
 begin
   driver.navigate.to LikadanUtils.construct_url('/')
 

--- a/lib/likadan_uploader.rb
+++ b/lib/likadan_uploader.rb
@@ -16,8 +16,10 @@ class LikadanUploader
 
     bucket = find_or_build_bucket
 
+    dir = SecureRandom.uuid
+
     diff_images = current_snapshots[:diffs].map do |diff|
-      image = bucket.objects.build("#{diff[:name]}_#{diff[:viewport]}.png")
+      image = bucket.objects.build("#{dir}/#{diff[:name]}_#{diff[:viewport]}.png")
       image.content = open(diff[:file])
       image.content_type = 'image/png'
       image.save
@@ -25,7 +27,7 @@ class LikadanUploader
       diff
     end
 
-    html = bucket.objects.build("#{SecureRandom.uuid}.html")
+    html = bucket.objects.build("#{dir}/index.html")
     html.content =
       ERB.new(
         File.read(File.expand_path(

--- a/lib/likadan_uploader.rb
+++ b/lib/likadan_uploader.rb
@@ -3,19 +3,18 @@ require 's3'
 require 'securerandom'
 
 class LikadanUploader
-  def initialize()
+  BUCKET_NAME = 'likadan-diffs'
+
+  def initialize
     @s3_access_key_id = LikadanUtils.config['s3_access_key_id']
     @s3_secret_access_key = LikadanUtils.config['s3_secret_access_key']
   end
 
   def upload_diffs
-    service = S3::Service.new(access_key_id: @s3_access_key_id,
-                              secret_access_key: @s3_secret_access_key)
     current_snapshots = LikadanUtils.current_snapshots
     return [] if current_snapshots[:diffs].empty?
 
-    bucket = service.buckets.build(SecureRandom.hex)
-    bucket.save(location: :us)
+    bucket = find_or_build_bucket
 
     diff_images = current_snapshots[:diffs].map do |diff|
       image = bucket.objects.build("#{diff[:name]}_#{diff[:viewport]}.png")
@@ -26,7 +25,7 @@ class LikadanUploader
       diff
     end
 
-    html = bucket.objects.build('likadan-diffs.html')
+    html = bucket.objects.build("#{SecureRandom.uuid}.html")
     html.content =
       ERB.new(
         File.read(File.expand_path(
@@ -35,5 +34,20 @@ class LikadanUploader
     html.content_type = 'text/html'
     html.save
     html.url
+  end
+
+  private
+
+  def find_or_build_bucket
+    service = S3::Service.new(access_key_id: @s3_access_key_id,
+                              secret_access_key: @s3_secret_access_key)
+    bucket = service.buckets.find(BUCKET_NAME)
+
+    if bucket.nil?
+      bucket = service.buckets.build(BUCKET_NAME)
+      bucket.save(location: :us)
+    end
+
+    bucket
   end
 end


### PR DESCRIPTION
We started seeing the following error when likadan runs in CI:

> You have attempted to create more buckets than allowed
> (S3::Error::TooManyBuckets)

I think we can avoid this by only creating one bucket instead of a new
bucket every time likadan runs. I simply moved the random bucket name to
be a random file name, and created a non-random bucket name.

I decided to switch from SecureRandom.hex to SecureRandom.uuid because
uuid seems more appropriate for this type of thing.

I considered making the filename for the diffs just be the MD5 hash of
the file, which would avoid us from uploading duplicate data if the two
files happened to be the same. However, I didn't think the little bit of
added complexity of finding if the file already exists was worth the
small gain of no duplicates at this time.

I wasn't exactly sure how to test this, so I'm not sure if it actually works.