### PR TITLE
Prevent one dimensional snapshots

### DIFF
--- a/lib/likadan_runner.rb
+++ b/lib/likadan_runner.rb
@@ -56,8 +56,8 @@ begin
       cropped = ChunkyPNG::Image.from_file(output_file)
       cropped.crop!(rendered['left'],
                     rendered['top'],
-                    rendered['width'],
-                    rendered['height'])
+                    [rendered['width'], 1].max,
+                    [rendered['height'], 1].max)
       cropped.save(output_file)
 
       print "Checking \"#{current['name']}\" at [#{viewport['name']}]... "

--- a/lib/views/index.erb
+++ b/lib/views/index.erb
@@ -17,7 +17,7 @@
         href="/resource?file=<%= ERB::Util.url_encode(stylesheet) %>">
     <% end %>
   </head>
-  <body style="background-color: #fff; margin: 0; min-height: 1px; pointer-events: none;">
+  <body style="background-color: #fff; margin: 0; pointer-events: none;">
     <script src="/likadan-runner.js"></script>
     <% @config['source_files'].each do |source_file| %>
       <script src="/resource?file=<%= ERB::Util.url_encode(source_file) %>"></script>

--- a/spec/likadan_spec.rb
+++ b/spec/likadan_spec.rb
@@ -72,6 +72,40 @@ describe 'likadan' do
     end
 
     context 'and there is a diff' do
+      context 'and the baseline has height' do
+        before do
+          run_likadan
+
+          File.open(File.join(@tmp_dir, 'examples.js'), 'w') do |f|
+            f.write(<<-EOS)
+              likadan.define('foo', function() {
+                var elem = document.createElement('div');
+                elem.innerHTML = 'Football';
+                document.body.appendChild(elem);
+                return elem;
+              }, #{example_config})
+            EOS
+          end
+        end
+
+        it 'keeps the baseline, and generates a diff' do
+          run_likadan
+          expect(snapshot_file_exists?('@large', 'baseline.png')).to be(true)
+          expect(snapshot_file_exists?('@large', 'diff.png')).to be(true)
+          expect(snapshot_file_exists?('@large', 'candidate.png')).to be(true)
+        end
+      end
+    end
+
+    context 'and the baseline does not have height' do
+      let(:examples_js) { <<-EOS }
+        likadan.define('foo', function() {
+          var elem = document.createElement('div');
+          document.body.appendChild(elem);
+          return elem;
+        }, #{example_config})
+      EOS
+
       before do
         run_likadan
 
@@ -79,7 +113,7 @@ describe 'likadan' do
           f.write(<<-EOS)
             likadan.define('foo', function() {
               var elem = document.createElement('div');
-              elem.innerHTML = 'Football';
+              elem.innerHTML = 'Foo';
               document.body.appendChild(elem);
               return elem;
             }, #{example_config})


### PR DESCRIPTION
In 39daf344 I added a min-height to the <body> element to prevent
snapshots from having 0 height when nothing is rendered. I had assumed
this would work, but I assumed incorrectly. This is because likadan
crops the snapshot to fit just the rendered element. To fix this for
real, I am just setting a minimum height and width of 1 on the cropping.

Fixes #23