### PR TITLE
Improve compatibility with things that require asynchronicity

### DIFF
--- a/lib/likadan_runner.rb
+++ b/lib/likadan_runner.rb
@@ -28,6 +28,7 @@ rescue Selenium::WebDriver::Error::WebDriverError
 end
 
 begin
+  driver.manage.timeouts.script_timeout = 3 # move to config?
   driver.navigate.to LikadanUtils.construct_url('/')
 
   # Check for errors during startup
@@ -42,7 +43,13 @@ begin
       driver.manage.window.resize_to(viewport['width'], viewport['height'])
 
       # Render the example
-      rendered = driver.execute_script('return window.likadan.renderCurrent()')
+
+      script = <<-EOS
+        var doneFunc = arguments[arguments.length - 1];
+        window.likadan.renderCurrent(doneFunc);
+      EOS
+      rendered = driver.execute_async_script(script)
+
       if error = rendered['error']
         puts <<-EOS
           Error while rendering "#{current['name']}" @#{viewport['name']}:

--- a/lib/public/likadan-runner.js
+++ b/lib/public/likadan-runner.js
@@ -56,10 +56,80 @@ window.likadan = {
     });
   },
 
-  renderCurrent: function() {
+  handleError: function(error) {
+    console.error(error);
+    return {
+      name: this.currentExample.name,
+      error: error.message
+    };
+  },
+
+  /**
+   * @param {Function} func The likadan.describe function from the current
+   *   example being rendered. This function takes a callback as an argument
+   *   that is called when it is done.
+   * @return {Promise}
+   */
+  tryAsync: function(func) {
+    return new Promise(function(resolve, reject) {
+      // Saftey valve: if the function does not finish after 3s, then something
+      // went haywire and we need to move on.
+      var timeout = setTimeout(function() {
+        reject(new Error('Async callback was not invoked within timeout.'));
+      }, 3000);
+
+      // This function is called by the example when it is done executing.
+      var doneCallback = function(elem) {
+        clearTimeout(timeout);
+
+        if (!arguments.length) {
+          return reject(new Error(
+            'The async done callback expects the rendered element as an ' +
+            'argument, but there were no arguments.'
+          ));
+        }
+
+        resolve(elem);
+      };
+
+      func(doneCallback);
+    });
+  },
+
+  /**
+   * @param {Function} doneFunc injected by driver.execute_async_script in
+   *   likadan_runner.rb
+   */
+  renderCurrent: function(doneFunc) {
     try {
       this.clearVisibleElements();
-      var elem = this.currentExample.func();
+
+      var func = this.currentExample.func;
+      if (func.length) {
+        // The function takes an argument, which is a callback that is called
+        // once it is done executing. This can be used to write functions that
+        // have asynchronous code in them.
+        this.tryAsync(func).then(function(elem) {
+          doneFunc(this.processElem(elem));
+        }.bind(this)).catch(function(error) {
+          doneFunc(this.handleError(error));
+        }.bind(this));
+      } else {
+        // The function does not take an argument, so we can run it
+        // synchronously.
+        var elem = func();
+        doneFunc(this.processElem(elem));
+      }
+    } catch (error) {
+      doneFunc(this.handleError(error));
+    }
+  },
+
+  processElem: function(elem) {
+    try {
+      // TODO: elem.getDOMNode is deprecated in React, so we need to convert
+      // this to React.findDOMNode(elem) at some point, or push this requirement
+      // into the examples.
       if (elem.getDOMNode) {
         // Soft-dependency to React here. If the thing returned has a
         // `getDOMNode` method, call it to get the real DOM node.
@@ -87,11 +157,7 @@ window.likadan = {
         left: left
       };
     } catch (error) {
-      console.error(error);
-      return {
-        name: this.currentExample.name,
-        error: error.message
-      };
+      return this.handleError(error);
     }
   }
 };

--- a/spec/likadan_spec.rb
+++ b/spec/likadan_spec.rb
@@ -176,4 +176,24 @@ describe 'likadan' do
       end
     end
   end
+
+  describe 'with doneCallback async argument' do
+    let(:examples_js) { <<-EOS }
+      likadan.define('foo', function(done) {
+        setTimeout(function() {
+          var elem = document.createElement('div');
+          elem.innerHTML = 'Foo';
+          document.body.appendChild(elem);
+          done(elem);
+        });
+      }, #{example_config})
+    EOS
+
+    it 'generates a baseline, but no diff' do
+      run_likadan
+      expect(snapshot_file_exists?('@large', 'baseline.png')).to be(true)
+      expect(snapshot_file_exists?('@large', 'diff.png')).to be(false)
+      expect(snapshot_file_exists?('@large', 'candidate.png')).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
At Brigade We have a likadan for a react component that uses
`requestAnimationFrame` when it renders to set some state. The snapshot
seems to sometimes be taken before this happens, and sometimes after it
happens. It would be nice if there was a way to ensure that the snapshot
is always taken after the `requestAnimationFrame`.

Jasmine solves this by having the function take a callback argument and
requiring the spec to call it when it is done. I think that a similar
technique will work for us here.

I implemented this by making the runner use WebDriver's
`execute_async_script` which injects a callback argument that needs to
be called when the script is done executing. This function can take a
value that gets passed back to Rubyland which we can use in the same way
as before to generate the snapshot. This allows us to write examples
that look like:

```js
likadan.define('foo', function(done) {
  setTimeout(function() {
    var elem = document.createElement('div');
    elem.innerHTML = 'Foo';
    document.body.appendChild(elem);
    done(elem);
  });
})
```

Fixes #28