### PR TITLE
Fail `likadan` if broken example is found

### DIFF
--- a/lib/likadan_runner.rb
+++ b/lib/likadan_runner.rb
@@ -50,14 +50,13 @@ begin
       EOS
       rendered = driver.execute_async_script(script)
 
-      if error = rendered['error']
-        puts <<-EOS
+      if rendered['error']
+        fail <<-EOS
           Error while rendering "#{current['name']}" @#{viewport['name']}:
             #{rendered['error']}
           Debug by pointing your browser to
           #{LikadanUtils.construct_url('/', name: current['name'])}
         EOS
-        next
       end
       output_file = LikadanUtils.path_to(
         current['name'], viewport['name'], 'candidate.png')


### PR DESCRIPTION
Previously, a `likadan` run would pass (exit code 0) even if there was
an example that was failing. This led us into accidentally pushing broken
examples to the Brigade codebase. Fixing by failing as soon as a failure
is found will help us prevent pushing bad eggs into the basket.